### PR TITLE
Hotfix for plist version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.2.2 (20.05.2026)
+
+**Bug fixes:**
+
+ -Tagged Plist version to a fix version (3.1.0) for Cordova 12
+
+
 ## 1.2.1 (2016-10-23)
 
 **Bug fixes:**

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "xml2js": ">=0.4",
     "rimraf": ">=2.4",
     "node-version-compare": ">=1.0.1",
-    "plist": ">=1.2.0"
+    "plist": "^3.1.0"
   },
   "author": "Nikolay Demyankov for Nordnet Bank AB",
   "license": "MIT",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin id="cordova-universal-links-plugin" version="1.2.1" xmlns="http://apache.org/cordova/ns/plugins/1.0">
+<plugin id="cordova-universal-links-plugin" version="1.2.2" xmlns="http://apache.org/cordova/ns/plugins/1.0">
 
   <name>Universal Links Plugin</name>
   <description>


### PR DESCRIPTION
This is a fix for plist verson to work with cordova 12. It adds a fix version instead the highest version.